### PR TITLE
Make it cold

### DIFF
--- a/heritage/gateway/src/main/kotlin/com/delbel/heritage/gateway/source/AssetsDataSource.kt
+++ b/heritage/gateway/src/main/kotlin/com/delbel/heritage/gateway/source/AssetsDataSource.kt
@@ -4,28 +4,23 @@ import android.content.res.AssetManager
 import com.delbel.heritage.gateway.model.HeritageDo
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import io.reactivex.Scheduler
 import io.reactivex.Single
 import java.io.IOException
 
 internal class AssetsDataSource constructor(
     private val assetsManager: AssetManager,
-    private val jsonParser: Gson
+    private val jsonParser: Gson,
+    private val scheduler: Scheduler
 ) {
 
     companion object {
         private const val FILE_NAME = "heritages.json"
     }
 
-    fun obtainAll() = Single.create<List<HeritageDo>> { emitter ->
-        try {
-            val jsonFromAssets = readJsonFromAsset()
-            val heritagesDo = convertToDto(json = jsonFromAssets)
-
-            emitter.onSuccess(heritagesDo)
-        } catch (e: IOException) {
-            emitter.onError(e)
-        }
-    }
+    fun obtainAll() = Single.fromCallable { readJsonFromAsset() }
+        .subscribeOn(scheduler)
+        .map { convertToDto(json = it) }
 
     @Throws(IOException::class)
     private fun readJsonFromAsset(): String {


### PR DESCRIPTION
Instead of creating the `Single.create()`, try to use `fromCallable{}` instead. This is a hot vs cold and you can find more details here: https://medium.com/@elye.project/rxjava-2-understanding-hot-vs-cold-with-just-vs-fromcallable-3c463f9f68c9

Also, I added a line of code that will break your unit test :party_parrot:. Could you identify why?

some tips: 
https://medium.com/@fabioCollini/testing-asynchronous-rxjava-code-using-mockito-8ad831a16877
https://medium.com/@PaulinaSadowska/writing-unit-tests-on-asynchronous-events-with-rxjava-and-rxkotlin-1616a27f69aa